### PR TITLE
Update CocoaLumberjack to v2.x

### DIFF
--- a/Core/XMPPLogging.h
+++ b/Core/XMPPLogging.h
@@ -59,7 +59,7 @@
  * If you created your project with a previous version of Xcode, you may need to add the DEBUG macro manually.
 **/
 
-#import "CocoaLumberJack/DDLog.h"
+#import "CocoaLumberJack/CocoaLumberjack.h"
 
 // Global flag to enable/disable logging throughout the entire xmpp framework.
 
@@ -122,10 +122,10 @@
 // These are primarily wrappers around the macros defined in Lumberjack's DDLog.h header file.
 
 #define XMPP_LOG_OBJC_MAYBE(async, lvl, flg, ctx, frmt, ...) \
-    do{ if(XMPP_LOGGING_ENABLED) LOG_MAYBE(async, lvl, flg, ctx, sel_getName(_cmd), frmt, ##__VA_ARGS__); } while(0)
+    do{ if(XMPP_LOGGING_ENABLED) LOG_MAYBE(async, lvl, flg, ctx, nil, sel_getName(_cmd), frmt, ##__VA_ARGS__); } while(0)
 
 #define XMPP_LOG_C_MAYBE(async, lvl, flg, ctx, frmt, ...) \
-    do{ if(XMPP_LOGGING_ENABLED) LOG_MAYBE(async, lvl, flg, ctx, __FUNCTION__, frmt, ##__VA_ARGS__); } while(0)
+    do{ if(XMPP_LOGGING_ENABLED) LOG_MAYBE(async, lvl, flg, ctx, nil, __FUNCTION__, frmt, ##__VA_ARGS__); } while(0)
 
 
 #define XMPPLogError(frmt, ...)    XMPP_LOG_OBJC_MAYBE(XMPP_LOG_ASYNC_ERROR,   xmppLogLevel, XMPP_LOG_FLAG_ERROR,  \

--- a/XMPPFramework.podspec
+++ b/XMPPFramework.podspec
@@ -50,7 +50,7 @@ core.libraries = 'xml2', 'resolv'
 core.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(inherited) $(SDKROOT)/usr/include/libxml2 $(PODS_ROOT)/XMPPFramework/module $(SDKROOT)/usr/include/libresolv',
 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/XMPPFramework/Vendor/libidn"', 'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES', 'OTHER_LDFLAGS' => '"-lxml2"', 'ENABLE_BITCODE' => 'NO'
 }
-core.dependency 'CocoaLumberjack','~>1.9'
+core.dependency 'CocoaLumberjack','~>2.0'
 core.dependency 'CocoaAsyncSocket','~>7.4.1'
 core.ios.dependency 'XMPPFramework/KissXML'
 end


### PR DESCRIPTION
I don't know if you are willing to upgrade CocoaLumberjack on this fork. 

We have done it as we are already using the 2.x version on our project and those changes are really lightweight. 
